### PR TITLE
this is the kernal module for systeminfo

### DIFF
--- a/sysinfo_kmod/Makefile
+++ b/sysinfo_kmod/Makefile
@@ -1,0 +1,11 @@
+obj-m += sysinfo_kmod.o
+
+KDIR ?= /lib/modules/$(shell uname -r)/build
+PWD  := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+

--- a/sysinfo_kmod/README.md
+++ b/sysinfo_kmod/README.md
@@ -1,0 +1,134 @@
+# 🚀 sysinfo\_kmod — Your Own Kernel-Powered System Info Tool
+
+> ✨ A **Linux Kernel Module** that creates a `/proc/sysinfo_kmod` entry and lets you peek directly into **uptime, memory usage, load averages, and kernel version** — straight from kernel space.
+
+---
+
+## 🎯 Features
+
+* 📊 **Uptime** in seconds since boot.
+* 🧠 **Total & Free RAM** in MB.
+* ⚖️ **Load Average** (1, 5, 15 minutes).
+* 🛠️ **Kernel Version** currently running.
+* 🔒 Safe, clean, removable anytime with `rmmod` or `modprobe -r`.
+
+---
+
+## ⚡ Quick Start
+
+### 1️⃣ Build
+
+```bash
+make
+```
+
+### 2️⃣ Load the module
+
+```bash
+sudo insmod sysinfo_kmod.ko   # OR recommended: sudo modprobe sysinfo_kmod
+```
+
+✅ Check kernel logs:
+
+```bash
+dmesg | tail
+```
+
+### 3️⃣ View system info
+
+```bash
+cat /proc/sysinfo_kmod
+```
+
+🔍 Example output:
+
+```
+===== System Information =====
+Uptime: 3500 seconds
+Total RAM: 16384 MB
+Free RAM : 12000 MB
+Load Avg : 0.05 0.10 0.20
+Kernel   : 5.14.0-422.el9.x86_64
+==============================
+```
+
+### 4️⃣ Remove the module
+
+```bash
+sudo rmmod sysinfo_kmod or modprob -r sysinfo_kmod
+```
+
+---
+
+## 🌀 Auto-load on Reboot
+
+Keep it alive across reboots:
+
+```bash
+sudo cp sysinfo_kmod.ko /lib/modules/$(uname -r)/extra/
+sudo depmod -a
+echo sysinfo_kmod | sudo tee /etc/modules-load.d/sysinfo_kmod.conf
+```
+
+---
+
+## 🎨 Developer Info
+
+* 👨‍💻 **Author:** Jyoti S. Tripathi
+* 📝 **Description:** System Info provider via /proc
+* 🔖 **Version:** 1.0
+* ⚖️ **License:** GPL
+
+Check anytime with:
+
+```bash
+modinfo sysinfo_kmod.ko
+```
+
+---
+
+## 🧩 Why Unique?
+
+Unlike a typical *Hello World* module, **sysinfo\_kmod** gives you **real-time, practical kernel data** that userspace tools like `free`, `uptime`, and `top` normally fetch indirectly.
+
+Here, you own the kernel logic 🚀 — tweak it to expose **custom monitoring metrics, security hooks, or even hidden Easter eggs** 😉.
+
+---
+
+## 🔥 Pro Tips
+
+* Combine with `watch` for live updates:
+
+```bash
+watch -n 2 cat /proc/sysinfo_kmod
+```
+
+* Extend code to log data into `/var/log/` or export via `sysfs`.
+* Package it into an RPM and share with your team!
+
+---
+
+## ✨ ASCII Art Vibes
+
+```
+   _____       _        _              _   _               _
+  / ____|     | |      | |            | | (_)             | |
+ | (___   __ _| |_ __ _| | ___   _ __ | |_ _  ___ ___  ___| |
+  \___ \ / _` | __/ _` | |/ _ \ | '_ \| __| |/ __/ _ \/ __| |
+  ____) | (_| | || (_| | |  __/ | | | | |_| | (_|  __/\__ \_|
+ |_____/ \__,_|\__\__,_|_|\___| |_| |_|\__|_|\___\___||___(_)
+```
+
+---
+
+## 🌌 The Big Picture
+
+This is not just a module. It’s your **entry point into kernel-space programming**:
+
+* Learn Linux internals 🐧
+* Build real device drivers ⚡
+* Craft monitoring/security modules 🔐
+
+**Welcome to Kernel Hacking 🚀** — You’re not reading `/proc`, you’re *owning it*.
+
+---

--- a/sysinfo_kmod/sysinfo_kmod.c
+++ b/sysinfo_kmod/sysinfo_kmod.c
@@ -1,0 +1,72 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/mm.h>
+#include <linux/sched/loadavg.h>
+#include <linux/jiffies.h>
+#include <linux/utsname.h>
+#include <linux/timekeeping.h>
+
+#define PROC_NAME "sysinfo_kmod"
+
+static int sysinfo_show(struct seq_file *m, void *v)
+{
+    struct sysinfo i;
+    si_meminfo(&i);
+
+    // uptime in seconds
+    unsigned long uptime = jiffies_to_msecs(get_jiffies_64()) / 1000;
+
+    seq_printf(m,
+        "===== System Information =====\n"
+        "Uptime: %lu seconds\n"
+        "Total RAM: %lu MB\n"
+        "Free RAM : %lu MB\n"
+        "Load Avg : %lu.%02lu %lu.%02lu %lu.%02lu\n"
+        "Kernel   : %s\n"
+        "==============================\n",
+        uptime,
+        (i.totalram * i.mem_unit) / (1024 * 1024),
+        (i.freeram * i.mem_unit) / (1024 * 1024),
+        LOAD_INT(avenrun[0]), LOAD_FRAC(avenrun[0]),
+        LOAD_INT(avenrun[1]), LOAD_FRAC(avenrun[1]),
+        LOAD_INT(avenrun[2]), LOAD_FRAC(avenrun[2]),
+        utsname()->release
+    );
+    return 0;
+}
+
+static int sysinfo_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, sysinfo_show, NULL);
+}
+
+static const struct proc_ops sysinfo_fops = {
+    .proc_open    = sysinfo_open,
+    .proc_read    = seq_read,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release,
+};
+
+static int __init sysinfo_init(void)
+{
+    proc_create(PROC_NAME, 0, NULL, &sysinfo_fops);
+    pr_info("sysinfo_kmod loaded\n");
+    return 0;
+}
+
+static void __exit sysinfo_exit(void)
+{
+    remove_proc_entry(PROC_NAME, NULL);
+    pr_info("sysinfo_kmod unloaded\n");
+}
+
+module_init(sysinfo_init);
+module_exit(sysinfo_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Jyoti Swaroop");
+MODULE_DESCRIPTION("System Information Kernel Module");
+


### PR DESCRIPTION
sysinfo is a lightweight and efficient command-line utility built in C,designed to give system administrators instant visibility into the health and status of a Linux system.  

With a single command, sysinfo aggregates and displays all essential metrics — saving time, simplifying diagnostics, and aiding quick decision-making in production and server environments.